### PR TITLE
multiple provenance

### DIFF
--- a/qcschema/dev/definitions.py
+++ b/qcschema/dev/definitions.py
@@ -35,7 +35,7 @@ definitions["provenance"] = {
             "type": "string"
         }
     },
-    "required": ["creator"],
+    "required": ["creator", "version", "routine"],
     "description": "A short provenance of the object.",
     "additionalProperties": True
 }

--- a/qcschema/dev/molecule.py
+++ b/qcschema/dev/molecule.py
@@ -134,8 +134,19 @@ molecule = {
             "type": "string"
         },
         "provenance": {
-            "type": "object",
-            "$ref": "#/definitions/provenance"
+            "anyOf": [
+                {
+                    "type": "object",
+                    "$ref": "#/definitions/provenance"
+                },
+                {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "$ref": "#/definitions/provenance"
+                    }
+                }
+            ]
         }
     },
     "required": ["symbols", "geometry"],


### PR DESCRIPTION
## Description
Data passes through many programs (e.g., molecule builder-->QC pkg-->vibrations visualizer or driver-->QC pkg-->harvester). While one can argue about what qualifies as "touching" the data, programs shouldn't be deciding whether they are the most important toucher (replace or initialize provenance info) or not (leave provenance alone). Instead, just let program add its fingerprint.

I'd prefer the field be always an array, but single allowed for back-compatibility.

## Questions
- [x] EDIT: https://github.com/MolSSI/QCSchema/blob/master/qcschema/dev/definitions.py#L29-L38 is ambiguous between whether all three fields required and version/routine blank or whether only creator is required. Should be clarified. I prefer all three required.

## Status
- [x] Ready to go
