### PR TITLE
qcschema_input and qcschema_molecule updating

### DIFF
--- a/qcschema/dev/dev_schema.py
+++ b/qcschema/dev/dev_schema.py
@@ -19,7 +19,7 @@ base_schema = {
         "molecule": molecule.molecule,
         "schema_name": {
             "type": "string",
-            "pattern": "^(qc_?schema)\W*"
+            "pattern": "^(qc_?schema)$"
         },
         "schema_version": {
             "type": "integer"
@@ -98,14 +98,14 @@ output_properties = {
 # Snapshot the input dev schema
 input_dev_schema = copy.deepcopy(base_schema)
 input_dev_schema["name"] = "qcschema_input"
-input_dev_schema["properties"]["schema_name"]["pattern"] = "^(qc_?schema_input)\W*"
+input_dev_schema["properties"]["schema_name"]["pattern"] = "^(qc_?schema_input)$"
 
 # Snapshot the input dev schema
 output_dev_schema = copy.deepcopy(base_schema)
 output_dev_schema["name"] = "qcschema_output"
 output_dev_schema["properties"].update(output_properties)
 output_dev_schema["required"].extend(["provenance", "properties", "success", "return_result"])
-output_dev_schema["properties"]["schema_name"]["pattern"] = "^(qc_?schema_output)\W*"
+output_dev_schema["properties"]["schema_name"]["pattern"] = "^(qc_?schema_output)$"
 
 # Build out the molecule schema
 molecule_dev_schema = copy.deepcopy(molecule.molecule)

--- a/qcschema/dev/dev_schema.py
+++ b/qcschema/dev/dev_schema.py
@@ -11,7 +11,7 @@ from . import properties
 # The base schema definition
 base_schema = {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "name": "qc_schema_input",
+    "name": "qcschema_input",
     "version": "1.dev",
     "description": "The MolSSI Quantum Chemistry Schema",
     "type": "object",
@@ -19,7 +19,7 @@ base_schema = {
         "molecule": molecule.molecule,
         "schema_name": {
             "type": "string",
-            "pattern": "\W*(qc_schema)\W*"
+            "pattern": "^(qc_?schema)\W*"
         },
         "schema_version": {
             "type": "integer"
@@ -97,15 +97,15 @@ output_properties = {
 
 # Snapshot the input dev schema
 input_dev_schema = copy.deepcopy(base_schema)
-input_dev_schema["name"] = "qc_schema_input"
-input_dev_schema["properties"]["schema_name"]["pattern"] = "\W*(qc_schema_input)\W*"
+input_dev_schema["name"] = "qcschema_input"
+input_dev_schema["properties"]["schema_name"]["pattern"] = "^(qc_?schema_input)\W*"
 
 # Snapshot the input dev schema
 output_dev_schema = copy.deepcopy(base_schema)
-output_dev_schema["name"] = "qc_schema_output"
+output_dev_schema["name"] = "qcschema_output"
 output_dev_schema["properties"].update(output_properties)
 output_dev_schema["required"].extend(["provenance", "properties", "success", "return_result"])
-output_dev_schema["properties"]["schema_name"]["pattern"] = "\W*(qc_schema_output)\W*"
+output_dev_schema["properties"]["schema_name"]["pattern"] = "^(qc_?schema_output)\W*"
 
 # Build out the molecule schema
 molecule_dev_schema = copy.deepcopy(molecule.molecule)

--- a/qcschema/dev/molecule.py
+++ b/qcschema/dev/molecule.py
@@ -11,7 +11,7 @@ molecule = {
         "schema_name": {
             "guidance": "required properties schema_name within molecule block (instead of 'qcschema_[in|out]put' from one level higher) starts with schema_name=qcschema_molecule and schema_version=2",
             "type": "string",
-            "pattern": "^(qcschema_molecule)\W*"
+            "pattern": "^(qcschema_molecule)$"
         },
         "schema_version": {
             "type": "integer"

--- a/qcschema/dev/molecule.py
+++ b/qcschema/dev/molecule.py
@@ -3,11 +3,19 @@ The json-schema for the Molecule definition
 """
 molecule = {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "name": "qc_schema_molecule",
-    "version": "dev",
+    "name": "qcschema_molecule",
+    "version": "2.dev",
     "description": "The MolSSI Quantum Chemistry Molecular Schema",
     "type": "object",
     "properties": {
+        "schema_name": {
+            "guidance": "required properties schema_name within molecule block (instead of 'qcschema_[in|out]put' from one level higher) starts with schema_name=qcschema_molecule and schema_version=2",
+            "type": "string",
+            "pattern": "^(qcschema_molecule)\W*"
+        },
+        "schema_version": {
+            "type": "integer"
+        },
         "symbols": {
             "description": "(nat, ) atom symbols in title case.",
             "type": "array",
@@ -156,6 +164,6 @@ molecule = {
             "$ref": "#/definitions/provenance"
         }
     },
-    "required": ["symbols", "geometry"],
+    "required": ["symbols", "geometry", "schema_name", "schema_version"],
     "description": "The physical cartesian representation of the molecular system"
 }

--- a/tests/basis/waterZr_energy_B3LYP_STO3G_DEF2_input.json
+++ b/tests/basis/waterZr_energy_B3LYP_STO3G_DEF2_input.json
@@ -2,6 +2,8 @@
   "schema_name": "qc_schema_input",
   "schema_version": 1,
   "molecule": {
+    "schema_name": "qcschema_molecule",
+    "schema_version": 2,
     "geometry": [
       0.0,
       0.0,

--- a/tests/basis/water_energy_B3LYP_631G_input.json
+++ b/tests/basis/water_energy_B3LYP_631G_input.json
@@ -2,6 +2,8 @@
   "schema_name": "qc_schema_input",
   "schema_version": 1,
   "molecule": {
+    "schema_name": "qcschema_molecule",
+    "schema_version": 2,
     "geometry": [
       0.0,
       0.0,

--- a/tests/simple/he2_energy_VV10_input.json
+++ b/tests/simple/he2_energy_VV10_input.json
@@ -2,6 +2,8 @@
   "schema_name": "qc_schema_input",
   "schema_version": 1,
   "molecule": {
+    "schema_name": "qcschema_molecule",
+    "schema_version": 2,
     "geometry": [
       0,
       0,

--- a/tests/simple/he2_energy_VV10_output.json
+++ b/tests/simple/he2_energy_VV10_output.json
@@ -2,6 +2,8 @@
   "schema_name": "qc_schema_output",
   "schema_version": 1,
   "molecule": {
+    "schema_name": "qcschema_molecule",
+    "schema_version": 2,
     "geometry": [
       0,
       0,

--- a/tests/simple/water_energy_B3LYP_input.json
+++ b/tests/simple/water_energy_B3LYP_input.json
@@ -2,6 +2,8 @@
   "schema_name": "qc_schema_input",
   "schema_version": 1,
   "molecule": {
+    "schema_name": "qcschema_molecule",
+    "schema_version": 2,
     "geometry": [
       0.0,
       0.0,

--- a/tests/simple/water_energy_B3LYP_output.json
+++ b/tests/simple/water_energy_B3LYP_output.json
@@ -2,6 +2,8 @@
   "schema_name": "qc_schema_output",
   "schema_version": 1,
   "molecule": {
+    "schema_name": "qcschema_molecule",
+    "schema_version": 2,
     "geometry": [
       0.0,
       0.0,

--- a/tests/simple/water_energy_MP2_input.json
+++ b/tests/simple/water_energy_MP2_input.json
@@ -1,7 +1,9 @@
 {
-  "schema_name": "qc_schema_input",
+  "schema_name": "qcschema_input",
   "schema_version": 1,
   "molecule": {
+    "schema_name": "qcschema_molecule",
+    "schema_version": 2,
     "geometry": [
       0.0,
       0.0,

--- a/tests/simple/water_energy_MP2_output.json
+++ b/tests/simple/water_energy_MP2_output.json
@@ -1,7 +1,9 @@
 {
-  "schema_name": "qc_schema_output",
+  "schema_name": "qcschema_output",
   "schema_version": 1,
   "molecule": {
+    "schema_name": "qcschema_molecule",
+    "schema_version": 2,
     "geometry": [
       0.0,
       0.0,

--- a/tests/simple/water_gradient_HF_input.json
+++ b/tests/simple/water_gradient_HF_input.json
@@ -2,6 +2,8 @@
   "schema_name": "qc_schema_input",
   "schema_version": 1,
   "molecule": {
+    "schema_name": "qcschema_molecule",
+    "schema_version": 2,
     "geometry": [
       0.0,
       0.0,

--- a/tests/simple/water_gradient_HF_output.json
+++ b/tests/simple/water_gradient_HF_output.json
@@ -2,6 +2,8 @@
   "schema_name": "qc_schema_output",
   "schema_version": 1,
   "molecule": {
+    "schema_name": "qcschema_molecule",
+    "schema_version": 2,
     "geometry": [
       0.0,
       0.0,


### PR DESCRIPTION
## Description
- [x] From discussion in #59, adds req'd fields `{'schema_name': 'qcschema_molecule', 'schema_version': 2}` _within_ molecule schema. closes #59 . qcelemental 0.2.7 will understand this as `dtype=2`.
- [x] Effectively in the QCA software stack, `qc_schema_[in|out]put` has been moving to `qcschema_[in|out]put`, so this PR expresses the patterns in regex. Also removes the possibility to say `sldkfjsl_qc_schema`, which I've never actually seen encoded. Postfix still allowed.

## Status
- [x] Ready to go
