### PR TITLE
Clean up basis set schema

### DIFF
--- a/qcschema/dev/__init__.py
+++ b/qcschema/dev/__init__.py
@@ -1,1 +1,1 @@
-from .dev_schema import input_dev_schema, output_dev_schema, molecule_dev_schema
+from .dev_schema import input_dev_schema, output_dev_schema, molecule_dev_schema, basis_dev_schema

--- a/qcschema/dev/basis.py
+++ b/qcschema/dev/basis.py
@@ -1,0 +1,46 @@
+"""
+The json-schema for the Basis Set definition
+"""
+
+basis = {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "name": "qcschema_basis",
+    "version": "1.dev",
+    "description": "The MolSSI Quantum Chemistry Basis Set Schema",
+    "type": "object",
+    "additionalProperties": False,
+    "properties": {
+        "schema_name": {
+            "type": "string",
+            "pattern": "^(qcschema_basis)$"
+        },
+        "schema_version": {
+            "type": "integer"
+        },
+        "description": {
+            "description": "Brief description of the basis set",
+            "type": "string"
+        },
+        "element_basis": {
+            "description": "Per-element basis data",
+            "type": "object",
+            "additionalProperties": False,
+            "patternProperties": {
+                "^\\d+$": {
+                    "$ref": "#/definitions/center_basis"
+                }
+            }
+        },
+        "atom_basis": {
+            "description":
+            "Basis set overrides for particular atoms or centers",
+            "type": "object",
+            "additionalProperties": False,
+            "patternProperties": {
+                "^\\d+$": {
+                    "$ref": "#/definitions/center_basis"
+                }
+            }
+        }
+    }
+}

--- a/qcschema/dev/basis.py
+++ b/qcschema/dev/basis.py
@@ -8,6 +8,10 @@ basis = {
     "version": "1.dev",
     "description": "The MolSSI Quantum Chemistry Basis Set Schema",
     "type": "object",
+    "required": [
+        "basis_data",
+        "basis_atom_map"
+    ],
     "additionalProperties": False,
     "properties": {
         "schema_name": {
@@ -21,25 +25,18 @@ basis = {
             "description": "Brief description of the basis set",
             "type": "string"
         },
-        "element_basis": {
-            "description": "Per-element basis data",
+        "basis_data": {
+            "description": "Basis data shared among all atoms/centers",
             "type": "object",
-            "additionalProperties": False,
-            "patternProperties": {
-                "^\\d+$": {
-                    "$ref": "#/definitions/center_basis"
-                }
+            "additionalProperties": {
+                "$ref": "#/definitions/center_basis"
             }
         },
-        "atom_basis": {
-            "description":
-            "Basis set overrides for particular atoms or centers",
-            "type": "object",
-            "additionalProperties": False,
-            "patternProperties": {
-                "^\\d+$": {
-                    "$ref": "#/definitions/center_basis"
-                }
+        "basis_atom_map": {
+            "description": "Mapping of atoms/centers to data in basis_data",
+            "type": "array",
+            "items": {
+                "type": "string"
             }
         }
     }

--- a/qcschema/dev/basis.py
+++ b/qcschema/dev/basis.py
@@ -26,14 +26,14 @@ basis = {
             "type": "string"
         },
         "basis_data": {
-            "description": "Basis data shared among all atoms/centers",
+            "description": "Shared basis data for all atoms/centers in the molecule",
             "type": "object",
             "additionalProperties": {
                 "$ref": "#/definitions/center_basis"
             }
         },
         "basis_atom_map": {
-            "description": "Mapping of atoms/centers to data in basis_data",
+            "description": "Mapping of all atoms/centers in the molecule to data in basis_data",
             "type": "array",
             "items": {
                 "type": "string"

--- a/qcschema/dev/definitions.py
+++ b/qcschema/dev/definitions.py
@@ -40,21 +40,17 @@ definitions["provenance"] = {
     "additionalProperties": True
 }
 
-definitions["basis_electron_shell"] = {
+definitions["electron_shell"] = {
     "description": "Information for a single electronic shell",
     "additionalProperties": False,
     "required": [
-        "shell_angular_momentum",
-        "shell_exponents",
-        "shell_coefficients"
+        "angular_momentum",
+        "harmonic_type",
+        "exponents",
+        "coefficients"
     ],
     "properties": {
-        "shell_region": {
-            "description": "The region this shell describes",
-            "type": "string",
-            "enum": [ "valence", "polarization", "core", "tight", "diffuse" ]
-        },
-        "shell_angular_momentum": {
+        "angular_momentum": {
             "description": "Angular momentum (as an array of integers)",
             "type": "array",
             "minItems": 1,
@@ -64,7 +60,12 @@ definitions["basis_electron_shell"] = {
                 "minimum": 0
             }
         },
-        "shell_exponents": {
+        "harmonic_type": {
+            "description": "Whether this shell is spherical or cartesian",
+            "type": "string",
+            "enum": ["spherical", "cartesian"]
+        },
+        "exponents": {
             "description": "Exponents for this contracted shell",
             "type": "array",
             "minItems": 1,
@@ -72,7 +73,7 @@ definitions["basis_electron_shell"] = {
                 "type": "string"
             }
         },
-        "shell_coefficients": {
+        "coefficients": {
             "description": "General contraction coefficients for this contracted shell",
             "type": "array",
             "minItems": 1,
@@ -86,23 +87,23 @@ definitions["basis_electron_shell"] = {
     }
 }
 
-definitions["basis_ecp_potential"] = {
+definitions["ecp_potential"] = {
     "description": "ECP potential",
     "additionalProperties": False,
     "required": [
-        "potential_ecp_type",
-        "potential_angular_momentum",
-        "potential_r_exponents",
-        "potential_gaussian_exponents",
-        "potential_coefficients"
+        "ecp_type",
+        "angular_momentum",
+        "r_exponents",
+        "gaussian_exponents",
+        "coefficients"
     ],
     "properties": {
-        "potential_ecp_type": {
+        "ecp_type": {
             "description": "Type of the ECP Potential",
             "type": "string",
             "enum": [ "scalar", "spinorbit" ]
         },
-        "potential_angular_momentum": {
+        "angular_momentum": {
             "description": "Angular momentum (as an array of integers)",
             "type": "array",
             "minItems": 1,
@@ -112,7 +113,7 @@ definitions["basis_ecp_potential"] = {
                 "minimum": 0
             }
         },
-        "potential_r_exponents": {
+        "r_exponents": {
             "description": "Exponents of the r term",
             "type": "array",
             "minItems": 1,
@@ -120,7 +121,7 @@ definitions["basis_ecp_potential"] = {
                 "type": "integer"
             }
         },
-        "potential_gaussian_exponents": {
+        "gaussian_exponents": {
             "description": "Exponents of the gaussian term",
             "type": "array",
             "minItems": 1,
@@ -128,8 +129,8 @@ definitions["basis_ecp_potential"] = {
                 "type": "string"
             }
         },
-        "potential_coefficients": {
-            "description": "General contraction coefficients for this contracted shell",
+        "coefficients": {
+            "description": "General contraction coefficients for this potential",
             "type": "array",
             "minItems": 1,
             "items": {
@@ -142,77 +143,34 @@ definitions["basis_ecp_potential"] = {
     }
 }
 
-definitions["basis_single_data"] = {
+definitions["center_basis"] = {
     "description": "Data for a single atom/center in the basis set",
     "type": "object",
     "additionalProperties": False,
     "properties": {
-        "element_electron_shells": {
+        "electron_shells": {
             "description": "(Electronic) shells for this element",
             "type": "array",
             "minItems": 1,
             "uniqueItems": True,
             "items": {
-                "$ref": "#/definitions/basis_electron_shell"
+                "$ref": "#/definitions/electron_shell"
             }
         },
-        "element_ecp_electrons":
+        "ecp_electrons":
         {
             "description": "Number of electrons replaced by ECP",
             "type": "integer",
             "minimum": 1
         },
-        "element_ecp": {
+        "ecp_potentials": {
             "description": "Effective Core Potential for this element",
             "type": "array",
             "minItems": 1,
             "uniqueItems": True,
             "items": {
-                "$ref": "#/definitions/basis_ecp_potential"
+                "$ref": "#/definitions/ecp_potential"
             }
         }
-    }
-}
-
-definitions["basis_spec"] = {
-    "description": "Specification for a basis applied to a molecule",
-    "type": "object",
-    "additionalProperties": False,
-    "properties":
-    {
-        "basis_set_description": {
-            "description": "Brief description of the basis set",
-            "type": "string"
-        },  
-        "basis_function_type": {
-            "description": "Type of function for this basis",
-            "type": "string",
-            "enum": [ "gto", "sto" ]
-        },
-        "basis_harmonic_type": {
-            "description": "Harmonic type (spherical, cartesian)",
-            "type": "string",
-            "enum": [ "spherical", "cartesian" ]
-        },
-        "basis_set_elements": {
-            "description": "Per-element basis data",
-            "type": "object",
-            "additionalProperties": False,
-            "patternProperties":   {   
-                "^\\d+$" : { 
-                    "$ref" : "#/definitions/basis_single_data"
-                }   
-            }   
-        },  
-        "basis_set_atoms": {
-            "description": "Basis set overrides for particular atoms or centers",
-            "type": "object",
-            "additionalProperties": False,
-            "patternProperties":   {   
-                "^\\d+$" : { 
-                    "$ref" : "#/definitions/basis_single_data"
-                }   
-            }   
-        }   
     }
 }

--- a/qcschema/dev/dev_schema.py
+++ b/qcschema/dev/dev_schema.py
@@ -36,20 +36,16 @@ base_schema = {
                     "type": "string"
                 },
                 "basis": {
-                    "type": "string",
-                    "description": "Name of the basis set to be applied to the whole molecule"
-                },
-                "basis_spec": basis.basis
-            },
-            "required": [ "method" ],
-            "oneOf": [
-                {
-                    "required": ["basis"]
-                },
-                {
-                    "required": ["basis_spec"]
+                  "anyOf": [
+                    basis.basis,
+                    {
+                        "description": "Name of the basis set to apply to the whole molecule",
+                        "type": "string"
+                    },
+                  ]
                 }
-            ],
+            },
+            "required": [ "method", "basis" ],
             "description": "The quantum chemistry model to be run."
         },
         "keywords": {

--- a/qcschema/dev/dev_schema.py
+++ b/qcschema/dev/dev_schema.py
@@ -7,6 +7,7 @@ import copy
 from . import molecule
 from . import definitions
 from . import properties
+from . import basis
 
 # The base schema definition
 base_schema = {
@@ -35,11 +36,10 @@ base_schema = {
                     "type": "string"
                 },
                 "basis": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Name of the basis set to be applied to the whole molecule"
                 },
-                "basis_spec": {
-                    "$ref": "#/definitions/basis_spec"
-                }
+                "basis_spec": basis.basis
             },
             "required": [ "method" ],
             "oneOf": [
@@ -109,6 +109,9 @@ output_dev_schema["properties"]["schema_name"]["pattern"] = "^(qc_?schema_output
 
 # Build out the molecule schema
 molecule_dev_schema = copy.deepcopy(molecule.molecule)
+
+# Build out the basis schema
+basis_dev_schema = copy.deepcopy(basis.basis)
 
 #import json
 #print(json.dumps(input_dev_schema, indent=2))

--- a/tests/basis/waterZr_energy_B3LYP_STO3G_DEF2_input.json
+++ b/tests/basis/waterZr_energy_B3LYP_STO3G_DEF2_input.json
@@ -28,10 +28,10 @@
   "driver": "energy",
   "model": {
     "method": "B3LYP",
-    "basis_spec": {
-      "description": "6-31G on all Hydrogen and Oxygen atom_basis",
-      "element_basis": {
-        "1": {
+    "basis": {
+      "description": "STO-3G on all Hydrogen and Oxygen, Def2-TZVP on Zr",
+      "basis_data": {
+        "bs_sto3g_h": {
           "electron_shells": [
             {
               "harmonic_type": "spherical",
@@ -53,7 +53,7 @@
             }
           ]
         },
-        "8": {
+        "bs_sto3g_o": {
           "electron_shells": [
             {
               "harmonic_type": "spherical",
@@ -98,10 +98,8 @@
               ]
             }
           ]
-        }
-      },
-      "atom_basis": {
-        "3": {
+        },
+        "bs_def2tzvp_zr": {
           "electron_shells": [
             {
               "harmonic_type": "spherical",
@@ -380,7 +378,13 @@
             }
           ]
         }
-      }
+      },
+      "basis_atom_map": [
+        "bs_sto3g_o",
+        "bs_sto3g_h",
+        "bs_sto3g_h",
+        "bs_def2tzvp_zr"
+      ]
     }
   },
   "keywords": {}

--- a/tests/basis/waterZr_energy_B3LYP_STO3G_DEF2_input.json
+++ b/tests/basis/waterZr_energy_B3LYP_STO3G_DEF2_input.json
@@ -29,23 +29,21 @@
   "model": {
     "method": "B3LYP",
     "basis_spec": {
-      "basis_set_description": "6-31G on all Hydrogen and Oxygen atoms",
-      "basis_function_type": "gto",
-      "basis_harmonic_type": "spherical",
-      "basis_set_elements": {
+      "description": "6-31G on all Hydrogen and Oxygen atom_basis",
+      "element_basis": {
         "1": {
-          "element_electron_shells": [
+          "electron_shells": [
             {
-              "shell_region": "valence",
-              "shell_angular_momentum": [
+              "harmonic_type": "spherical",
+              "angular_momentum": [
                 0
               ],
-              "shell_exponents": [
+              "exponents": [
                 "3.42525091",
                 "0.62391373",
                 "0.16885540"
               ],
-              "shell_coefficients": [
+              "coefficients": [
                 [
                   "0.15432897",
                   "0.53532814",
@@ -56,18 +54,18 @@
           ]
         },
         "8": {
-          "element_electron_shells": [
+          "electron_shells": [
             {
-              "shell_region": "valence",
-              "shell_angular_momentum": [
+              "harmonic_type": "spherical",
+              "angular_momentum": [
                 0
               ],
-              "shell_exponents": [
+              "exponents": [
                 "130.70932",
                 "23.808861",
                 "6.4436083"
               ],
-              "shell_coefficients": [
+              "coefficients": [
                 [
                   "0.15432897",
                   "0.53532814",
@@ -76,17 +74,17 @@
               ]
             },
             {
-              "shell_region": "valence",
-              "shell_angular_momentum": [
+              "harmonic_type": "spherical",
+              "angular_momentum": [
                 0,
                 1
               ],
-              "shell_exponents": [
+              "exponents": [
                 "5.0331513",
                 "1.1695961",
                 "0.3803890"
               ],
-              "shell_coefficients": [
+              "coefficients": [
                 [
                   "-0.09996723",
                   "0.39951283",
@@ -102,15 +100,15 @@
           ]
         }
       },
-      "basis_set_atoms": {
+      "atom_basis": {
         "3": {
-          "element_electron_shells": [
+          "electron_shells": [
             {
-              "shell_region": "valence",
-              "shell_angular_momentum": [
+              "harmonic_type": "spherical",
+              "angular_momentum": [
                 0
               ],
-              "shell_exponents": [
+              "exponents": [
                 "11.000000000",
                 "9.5000000000",
                 "3.6383667759",
@@ -119,7 +117,7 @@
                 "0.75261298085E-01",
                 "0.30131404705E-01"
               ],
-              "shell_coefficients": [
+              "coefficients": [
                 [
                   "-0.19075595257",
                   "0.33895588754",
@@ -177,11 +175,11 @@
               ]
             },
             {
-              "shell_region": "valence",
-              "shell_angular_momentum": [
+              "harmonic_type": "spherical",
+              "angular_momentum": [
                 1
               ],
-              "shell_exponents": [
+              "exponents": [
                 "8.6066305543",
                 "4.4400979958",
                 "1.1281026946",
@@ -190,7 +188,7 @@
                 "0.85000000000E-01",
                 "0.29000000000E-01"
               ],
-              "shell_coefficients": [
+              "coefficients": [
                 [
                   "0.40404260236E-01",
                   "-0.21187745201",
@@ -230,18 +228,18 @@
               ]
             },
             {
-              "shell_region": "valence",
-              "shell_angular_momentum": [
+              "harmonic_type": "spherical",
+              "angular_momentum": [
                 2
               ],
-              "shell_exponents": [
+              "exponents": [
                 "4.5567957795",
                 "1.2904939797",
                 "0.51646987222",
                 "0.19349797794",
                 "0.67309809967E-01"
               ],
-              "shell_coefficients": [
+              "coefficients": [
                 [
                   "-0.96190569023E-02",
                   "0.20569990155",
@@ -266,36 +264,36 @@
               ]
             },
             {
-              "shell_region": "valence",
-              "shell_angular_momentum": [
+              "harmonic_type": "spherical",
+              "angular_momentum": [
                 3
               ],
-              "shell_exponents": [
+              "exponents": [
                 "0.3926100"
               ],
-              "shell_coefficients": [
+              "coefficients": [
                 [
                   "1.0000000"
                 ]
               ]
             }
           ],
-          "element_ecp_electrons": 28,
-          "element_ecp": [
+          "ecp_electrons": 28,
+          "ecp_potentials": [
             {
-              "potential_ecp_type": "scalar",
-              "potential_angular_momentum": [
+              "ecp_type": "scalar",
+              "angular_momentum": [
                 3
               ],
-              "potential_r_exponents": [
+              "r_exponents": [
                 2,
                 2
               ],
-              "potential_gaussian_exponents": [
+              "gaussian_exponents": [
                 "6.5842120",
                 "3.2921060"
               ],
-              "potential_coefficients": [
+              "coefficients": [
                 [
                   "-19.12219811",
                   "-2.43637543"
@@ -303,23 +301,23 @@
               ]
             },
             {
-              "potential_ecp_type": "scalar",
-              "potential_angular_momentum": [
+              "ecp_type": "scalar",
+              "angular_momentum": [
                 0
               ],
-              "potential_r_exponents": [
+              "r_exponents": [
                 2,
                 2,
                 2,
                 2
               ],
-              "potential_gaussian_exponents": [
+              "gaussian_exponents": [
                 "7.4880494",
                 "3.7440247",
                 "6.5842120",
                 "3.2921060"
               ],
-              "potential_coefficients": [
+              "coefficients": [
                 [
                   "135.15384412",
                   "15.55244130",
@@ -329,23 +327,23 @@
               ]
             },
             {
-              "potential_ecp_type": "scalar",
-              "potential_angular_momentum": [
+              "ecp_type": "scalar",
+              "angular_momentum": [
                 1
               ],
-              "potential_r_exponents": [
+              "r_exponents": [
                 2,
                 2,
                 2,
                 2
               ],
-              "potential_gaussian_exponents": [
+              "gaussian_exponents": [
                 "6.4453772",
                 "3.2226886",
                 "6.5842120",
                 "3.2921060"
               ],
-              "potential_coefficients": [
+              "coefficients": [
                 [
                   "87.78499167",
                   "11.56406599",
@@ -355,23 +353,23 @@
               ]
             },
             {
-              "potential_ecp_type": "scalar",
-              "potential_angular_momentum": [
+              "ecp_type": "scalar",
+              "angular_momentum": [
                 2
               ],
-              "potential_r_exponents": [
+              "r_exponents": [
                 2,
                 2,
                 2,
                 2
               ],
-              "potential_gaussian_exponents": [
+              "gaussian_exponents": [
                 "4.6584472",
                 "2.3292236",
                 "6.5842120",
                 "3.2921060"
               ],
-              "potential_coefficients": [
+              "coefficients": [
                 [
                   "29.70100072",
                   "5.53996847",

--- a/tests/basis/water_energy_B3LYP_631G_input.json
+++ b/tests/basis/water_energy_B3LYP_631G_input.json
@@ -25,23 +25,21 @@
   "model": {
     "method": "B3LYP",
     "basis_spec": {
-      "basis_set_description": "6-31G on all Hydrogen and Oxygen atoms",
-      "basis_function_type": "gto",
-      "basis_harmonic_type": "spherical",
-      "basis_set_elements": {
+      "description": "6-31G on all Hydrogen and Oxygen atoms",
+      "element_basis": {
         "1": {
-          "element_electron_shells": [
+          "electron_shells": [
             {
-              "shell_region": "valence",
-              "shell_angular_momentum": [
+              "harmonic_type": "spherical",
+              "angular_momentum": [
                 0
               ],
-              "shell_exponents": [
+              "exponents": [
                 "18.731137",
                 "2.8253944",
                 "0.6401217"
               ],
-              "shell_coefficients": [
+              "coefficients": [
                 [
                   "0.0334946",
                   "0.2347269",
@@ -50,14 +48,14 @@
               ]
             },
             {
-              "shell_region": "valence",
-              "shell_angular_momentum": [
+              "harmonic_type": "spherical",
+              "angular_momentum": [
                 0
               ],
-              "shell_exponents": [
+              "exponents": [
                 "0.1612778"
               ],
-              "shell_coefficients": [
+              "coefficients": [
                 [
                   "1.0000000"
                 ]
@@ -66,13 +64,13 @@
           ]
         },
         "8": {
-          "element_electron_shells": [
+          "electron_shells": [
             {
-              "shell_region": "valence",
-              "shell_angular_momentum": [
+              "harmonic_type": "spherical",
+              "angular_momentum": [
                 0
               ],
-              "shell_exponents": [
+              "exponents": [
                 "5484.6717000",
                 "825.2349500",
                 "188.0469600",
@@ -80,7 +78,7 @@
                 "16.8975700",
                 "5.7996353"
               ],
-              "shell_coefficients": [
+              "coefficients": [
                 [
                   "0.0018311",
                   "0.0139501",
@@ -92,17 +90,17 @@
               ]
             },
             {
-              "shell_region": "valence",
-              "shell_angular_momentum": [
+              "harmonic_type": "spherical",
+              "angular_momentum": [
                 0,
                 1
               ],
-              "shell_exponents": [
+              "exponents": [
                 "15.5396160",
                 "3.5999336",
                 "1.0137618"
               ],
-              "shell_coefficients": [
+              "coefficients": [
                 [
                   "-0.1107775",
                   "-0.1480263",
@@ -116,15 +114,15 @@
               ]
             },
             {
-              "shell_region": "valence",
-              "shell_angular_momentum": [
+              "harmonic_type": "spherical",
+              "angular_momentum": [
                 0,
                 1
               ],
-              "shell_exponents": [
+              "exponents": [
                 "0.2700058"
               ],
-              "shell_coefficients": [
+              "coefficients": [
                 [
                   "1.0000000"
                 ],

--- a/tests/basis/water_energy_B3LYP_631G_input.json
+++ b/tests/basis/water_energy_B3LYP_631G_input.json
@@ -24,10 +24,10 @@
   "driver": "energy",
   "model": {
     "method": "B3LYP",
-    "basis_spec": {
+    "basis": {
       "description": "6-31G on all Hydrogen and Oxygen atoms",
-      "element_basis": {
-        "1": {
+      "basis_data": {
+        "bs_631g_h": {
           "electron_shells": [
             {
               "harmonic_type": "spherical",
@@ -63,7 +63,7 @@
             }
           ]
         },
-        "8": {
+        "bs_631g_o": {
           "electron_shells": [
             {
               "harmonic_type": "spherical",
@@ -133,7 +133,12 @@
             }
           ]
         }
-      }
+      },
+      "basis_atom_map": [
+        "bs_631g_o",
+        "bs_631g_h",
+        "bs_631g_h"
+      ]
     }
   },
   "keywords": {}


### PR DESCRIPTION
## Description

This removes some of the redundant prefixes, and in general harmonizes the schema with changes done to the BSE over the last few months.

The basis set schema is now split into its own file, with definitions still residing (for now) in the definitions file.

No changes are made to the usual way of specifying a basis set via name.

Once this is merged, I can make the converter for the BSE to output the QCSchema format (https://github.com/MolSSI-BSE/basis_set_exchange/issues/44)

## Status
- [X] Ready to go