### PR TITLE
[WIP] Wavefunction output schema

### DIFF
--- a/docs/source/gen_schema_docs.py
+++ b/docs/source/gen_schema_docs.py
@@ -114,6 +114,7 @@ wf_categories = [
     ("Result", """
 A list of fields comprising the primary result information. 
 e.g. SCF quantities for a DFT calculation and MP2 quantities for an MP2 calculation.  
+Result fields contain the names of other fields in the wavefunction schema.
 """, result_wf),
     ("Self-Consistent Field", """
 A list of fields added at the self-consistent field (SCF) level. This includes

--- a/docs/source/gen_schema_docs.py
+++ b/docs/source/gen_schema_docs.py
@@ -13,11 +13,12 @@ import schema_doc_helpers as sh
 
 scf_props = qcschema.dev.properties.scf_properties.scf_properties
 mp_props = qcschema.dev.properties.mp_properties.mp_properties
+cc_props = qcschema.dev.properties.cc_properties.cc_properties
 calcinfo_props = qcschema.dev.properties.calcinfo_properties.calcinfo_properties
 
 ### Schema Properties
 
-prop_file = ["Schema Properties"]
+prop_file = ["Properties Schema"]
 prop_file.append("=" * len(prop_file[-1]))
 
 prop_file.extend("""
@@ -32,9 +33,12 @@ A list of fields that involve basic information of the requested computation.
 A list of fields added at the self-consistent field (SCF) level. This includes
 both Hartree--Fock and Density Functional Theory.
 """, scf_props),
-    ("Moller-Plesset", """
-A list of fields added at the Moller-Plesset (MP) level.
+    ("Møller-Plesset", """
+A list of fields added at the Møller--Plesset (MP) level.
 """, mp_props),
+    ("Coupled Cluster", """
+A list of fields added at the Coupled Cluster (CC) level.
+""", cc_props),
 ]
 
 for cat in prop_categories:
@@ -51,7 +55,7 @@ with open("auto_props.rst", "w") as outfile:
 
 ### Schema Topology
 
-top_file = ["Schema Topology"]
+top_file = ["Topology Schema"]
 top_file.append("=" * len(top_file[-1]))
 
 top_file.extend("""
@@ -83,3 +87,92 @@ sh.write_key_table(top_file, topo_props, set(topo_props.keys()) - set(topo_req))
 # Write out the file
 with open("auto_topology.rst", "w") as outfile:
     outfile.write("\n".join(top_file))
+
+
+### Wavefunction Properties
+
+result_wf = qcschema.dev.wavefunction.result_wavefunction.result_wavefunction
+scf_wf = qcschema.dev.wavefunction.scf_wavefunction.scf_wavefunction
+localized_wf = qcschema.dev.wavefunction.localized_wavefunction.localized_wavefunction
+core_wf = qcschema.dev.wavefunction.core_wavefunction.core_wavefunction
+
+wf_file = ["Wavefunction Schema"]
+wf_file.append("=" * len(wf_file[-1]))
+
+wf_file.extend("""
+A list of valid quantum chemistry wavefunction properties tracked by the schema.
+Matrices are in column-major order.
+AO basis functions are ordered according to the CCA standard. [TODO]
+""".splitlines())
+
+sh.write_header(wf_file, "Basis Set")
+wf_file.extend("""
+One-electron AO basis set. See :doc:`auto_basis`.
+""".splitlines())
+
+wf_categories = [
+    ("Result", """
+A list of fields comprising the primary result information. 
+e.g. SCF quantities for a DFT calculation and MP2 quantities for an MP2 calculation.  
+""", result_wf),
+    ("Self-Consistent Field", """
+A list of fields added at the self-consistent field (SCF) level. This includes
+both Hartree--Fock and Density Functional Theory.
+""", scf_wf),
+    ("Localized Orbitals", """
+A list of fields added at by orbital localization. 
+Full MO matrices are stored even if only a subset of MOs are localized.
+""", localized_wf),
+    ("Core Hamiltonian", """
+A list of fields associated with (effective) one-electron (AKA) core Hamiltonians. 
+""", core_wf)
+]
+
+for cat in wf_categories:
+    sh.write_header(wf_file, cat[0])
+
+    wf_file.extend(cat[1].splitlines())
+    wf_file.append("")
+
+    sh.write_key_table(wf_file, cat[2])
+
+# Write out the file
+with open("auto_wf.rst", "w") as outfile:
+    outfile.write("\n".join(wf_file))
+
+
+### Schema Basis
+
+basis_file = ["Basis Set Schema"]
+basis_file.append("=" * len(basis_file[-1]))
+
+basis_file.extend("""
+A full description of the basis set. 
+""".splitlines())
+
+basis_props = qcschema.dev.basis.basis["properties"]
+basis_req = qcschema.dev.basis.basis["required"]
+
+sh.write_header(basis_file, "Required Keys")
+
+basis_file.extend("""
+The following properties are required for a basis set.
+
+""".splitlines())
+
+sh.write_key_table(basis_file, basis_props, basis_req)
+
+### Optional properties
+sh.write_header(basis_file, "Optional Keys")
+
+basis_file.extend("""
+The following keys are optional for the basis set specification.
+
+""".splitlines())
+
+sh.write_key_table(basis_file, basis_props, set(basis_props.keys()) - set(basis_req))
+
+# Write out the file
+with open("auto_basis.rst", "w") as outfile:
+    outfile.write("\n".join(basis_file))
+

--- a/docs/source/gen_schema_docs.py
+++ b/docs/source/gen_schema_docs.py
@@ -102,7 +102,8 @@ wf_file.append("=" * len(wf_file[-1]))
 wf_file.extend("""
 A list of valid quantum chemistry wavefunction properties tracked by the schema.
 Matrices are in column-major order.
-AO basis functions are ordered according to the CCA standard. [TODO]
+AO basis functions are ordered according to the 
+`CCA standard as implemented in libint <https://github.com/evaleev/libint/wiki/using-modern-CPlusPlus-API#solid-harmonic-gaussians-ordering-and-normalization>`_.
 """.splitlines())
 
 sh.write_header(wf_file, "Basis Set")

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -84,3 +84,5 @@ Contents
    
    auto_topology
    auto_props
+   auto_wf
+   auto_basis

--- a/docs/source/schema_doc_helpers/writers.py
+++ b/docs/source/schema_doc_helpers/writers.py
@@ -38,10 +38,6 @@ def write_key_table(top_file, properties, keys=None):
 
         dtype = value["type"]
 
-        print(top_file)
-        print(properties)
-        print(f"key {key}")
-        print(value)
         if "description" in value:
             description = value["description"]
         elif value["type"] == "object":

--- a/docs/source/schema_doc_helpers/writers.py
+++ b/docs/source/schema_doc_helpers/writers.py
@@ -31,27 +31,33 @@ def write_key_table(top_file, properties, keys=None):
     top_file.append("   +={}=+={}=+={}=+".format(*equals_inds))
   
     if keys is None:
-        keys = properties.keys() 
+        keys = properties.keys()
 
     for key in keys:
         value = properties[key]
-   
+
         dtype = value["type"]
-   
-        if value["type"] == "object":
+
+        print(top_file)
+        print(properties)
+        print(f"key {key}")
+        print(value)
+        if "description" in value:
+            description = value["description"]
+        elif value["type"] == "object":
             description = value["$ref"]
         else:
-            description = value["description"]
-   
+            description = "No description provided."
+
         if value["type"] == "array":
             dtype = "array[" + value["items"]["type"] + "]"
-   
+
         # Figure out the needed slices
-   
+
         desc_parts = textwrap.wrap(description, width=table_widths[1])
         top_file.append(fmt_string.format(key, desc_parts[0], dtype))
-   
+
         for dp in desc_parts[1:]:
             top_file.append(fmt_string.format("", dp, ""))
-   
+
         top_file.append("   +-{}-+-{}-+-{}-+".format(*dash_inds))

--- a/qcschema/dev/basis.py
+++ b/qcschema/dev/basis.py
@@ -10,7 +10,8 @@ basis = {
     "type": "object",
     "required": [
         "basis_data",
-        "basis_atom_map"
+        "basis_atom_map",
+        "name"
     ],
     "additionalProperties": False,
     "properties": {
@@ -20,6 +21,10 @@ basis = {
         },
         "schema_version": {
             "type": "integer"
+        },
+        "name": {
+            "description": "Name of the basis set",
+            "type": "string"
         },
         "description": {
             "description": "Brief description of the basis set",

--- a/qcschema/dev/basis.py
+++ b/qcschema/dev/basis.py
@@ -9,8 +9,8 @@ basis = {
     "description": "The MolSSI Quantum Chemistry Basis Set Schema",
     "type": "object",
     "required": [
-        "basis_data",
-        "basis_atom_map",
+        "center_data",
+        "atom_map",
         "name"
     ],
     "additionalProperties": False,
@@ -30,15 +30,15 @@ basis = {
             "description": "Brief description of the basis set",
             "type": "string"
         },
-        "basis_data": {
+        "center_data": {
             "description": "Shared basis data for all atoms/centers in the molecule",
             "type": "object",
             "additionalProperties": {
                 "$ref": "#/definitions/center_basis"
             }
         },
-        "basis_atom_map": {
-            "description": "Mapping of all atoms/centers in the molecule to data in basis_data",
+        "atom_map": {
+            "description": "Mapping of all atoms/centers in the molecule to data in center_data",
             "type": "array",
             "items": {
                 "type": "string"

--- a/qcschema/dev/definitions.py
+++ b/qcschema/dev/definitions.py
@@ -81,7 +81,7 @@ definitions["electron_shell"] = {
                 "description": "Segmented contraction coefficients",
                 "type": "array",
                 "minItems": 1,
-                "items": { "type": "string" }
+                "items": {"type": "string"}
             }
         }
     }

--- a/qcschema/dev/dev_schema.py
+++ b/qcschema/dev/dev_schema.py
@@ -8,6 +8,7 @@ from . import molecule
 from . import definitions
 from . import properties
 from . import basis
+from . import wavefunction
 
 # The base schema definition
 base_schema = {
@@ -100,6 +101,7 @@ input_dev_schema["properties"]["schema_name"]["pattern"] = "^(qc_?schema_input)$
 output_dev_schema = copy.deepcopy(base_schema)
 output_dev_schema["name"] = "qcschema_output"
 output_dev_schema["properties"].update(output_properties)
+output_dev_schema["properties"]["wavefunction"] = wavefunction.output_wavefunction
 output_dev_schema["required"].extend(["provenance", "properties", "success", "return_result"])
 output_dev_schema["properties"]["schema_name"]["pattern"] = "^(qc_?schema_output)$"
 

--- a/qcschema/dev/wavefunction/__init__.py
+++ b/qcschema/dev/wavefunction/__init__.py
@@ -1,0 +1,1 @@
+from .wavefunction_base import output_wavefunction

--- a/qcschema/dev/wavefunction/core_wavefunction.py
+++ b/qcschema/dev/wavefunction/core_wavefunction.py
@@ -7,14 +7,14 @@ core_wavefunction = {}
 # core hamiltonian
 core_wavefunction["h_core_a"] = {
     "type": "array",
-    "description": "Alpha-spin core (one-electron) Hamiltonian",
+    "description": "Alpha-spin core (one-electron) Hamiltonian in the AO basis",
     "items": {"type": "number"}
 }
 
 
 core_wavefunction["h_core_b"] = {
     "type": "array",
-    "description": "Beta-spin core (one-electron) Hamiltonian",
+    "description": "Beta-spin core (one-electron) Hamiltonian in the AO basis",
     "items": {"type": "number"}
 }
 
@@ -22,13 +22,13 @@ core_wavefunction["h_core_b"] = {
 # effective core hamiltonian
 core_wavefunction["h_eff_a"] = {
     "type": "array",
-    "description": "Alpha-spin effective core (one-electron) Hamiltonian",
+    "description": "Alpha-spin effective core (one-electron) Hamiltonian in the AO basis",
     "items": {"type": "number"}
 }
 
 
 core_wavefunction["h_eff_b"] = {
     "type": "array",
-    "description": "Beta-spin effective core (one-electron) Hamiltonian",
+    "description": "Beta-spin effective core (one-electron) Hamiltonian in the AO basis",
     "items": {"type": "number"}
 }

--- a/qcschema/dev/wavefunction/core_wavefunction.py
+++ b/qcschema/dev/wavefunction/core_wavefunction.py
@@ -20,14 +20,14 @@ core_wavefunction["h_core_b"] = {
 
 
 # effective core hamiltonian
-core_wavefunction["h_eff_a"] = {
+core_wavefunction["h_effective_a"] = {
     "type": "array",
     "description": "Alpha-spin effective core (one-electron) Hamiltonian in the AO basis",
     "items": {"type": "number"}
 }
 
 
-core_wavefunction["h_eff_b"] = {
+core_wavefunction["h_effective_b"] = {
     "type": "array",
     "description": "Beta-spin effective core (one-electron) Hamiltonian in the AO basis",
     "items": {"type": "number"}

--- a/qcschema/dev/wavefunction/core_wavefunction.py
+++ b/qcschema/dev/wavefunction/core_wavefunction.py
@@ -7,7 +7,7 @@ core_wavefunction = {}
 # core hamiltonian
 core_wavefunction["h_core_a"] = {
     "type": "array",
-    "description": "Alpha-spin core (one-electron) Hamiltonian in the AO basis",
+    "description": "Alpha-spin core (one-electron) Hamiltonian in the AO basis.",
     "items": {"type": "number"},
     "shape": {"nao", "nao"}
 }
@@ -15,7 +15,7 @@ core_wavefunction["h_core_a"] = {
 
 core_wavefunction["h_core_b"] = {
     "type": "array",
-    "description": "Beta-spin core (one-electron) Hamiltonian in the AO basis",
+    "description": "Beta-spin core (one-electron) Hamiltonian in the AO basis.",
     "items": {"type": "number"},
     "shape": {"nao", "nao"}
 }
@@ -24,7 +24,7 @@ core_wavefunction["h_core_b"] = {
 # effective core hamiltonian
 core_wavefunction["h_effective_a"] = {
     "type": "array",
-    "description": "Alpha-spin effective core (one-electron) Hamiltonian in the AO basis",
+    "description": "Alpha-spin effective core (one-electron) Hamiltonian in the AO basis.",
     "items": {"type": "number"},
     "shape": {"nao", "nao"}
 }
@@ -32,7 +32,7 @@ core_wavefunction["h_effective_a"] = {
 
 core_wavefunction["h_effective_b"] = {
     "type": "array",
-    "description": "Beta-spin effective core (one-electron) Hamiltonian in the AO basis",
+    "description": "Beta-spin effective core (one-electron) Hamiltonian in the AO basis.",
     "items": {"type": "number"},
     "shape": {"nao", "nao"}
 }

--- a/qcschema/dev/wavefunction/core_wavefunction.py
+++ b/qcschema/dev/wavefunction/core_wavefunction.py
@@ -1,0 +1,34 @@
+"""
+(Effective) core (aka one-electron) Hamiltonian
+"""
+
+core_wavefunction = {}
+
+# core hamiltonian
+core_wavefunction["h_core_a"] = {
+    "type": "array",
+    "description": "Alpha-spin core (one-electron) Hamiltonian",
+    "items": {"type": "number"}
+}
+
+
+core_wavefunction["h_core_b"] = {
+    "type": "array",
+    "description": "Beta-spin core (one-electron) Hamiltonian",
+    "items": {"type": "number"}
+}
+
+
+# effective core hamiltonian
+core_wavefunction["h_eff_a"] = {
+    "type": "array",
+    "description": "Alpha-spin effective core (one-electron) Hamiltonian",
+    "items": {"type": "number"}
+}
+
+
+core_wavefunction["h_eff_b"] = {
+    "type": "array",
+    "description": "Beta-spin effective core (one-electron) Hamiltonian",
+    "items": {"type": "number"}
+}

--- a/qcschema/dev/wavefunction/core_wavefunction.py
+++ b/qcschema/dev/wavefunction/core_wavefunction.py
@@ -8,14 +8,16 @@ core_wavefunction = {}
 core_wavefunction["h_core_a"] = {
     "type": "array",
     "description": "Alpha-spin core (one-electron) Hamiltonian in the AO basis",
-    "items": {"type": "number"}
+    "items": {"type": "number"},
+    "shape": {"nao", "nao"}
 }
 
 
 core_wavefunction["h_core_b"] = {
     "type": "array",
     "description": "Beta-spin core (one-electron) Hamiltonian in the AO basis",
-    "items": {"type": "number"}
+    "items": {"type": "number"},
+    "shape": {"nao", "nao"}
 }
 
 
@@ -23,12 +25,14 @@ core_wavefunction["h_core_b"] = {
 core_wavefunction["h_effective_a"] = {
     "type": "array",
     "description": "Alpha-spin effective core (one-electron) Hamiltonian in the AO basis",
-    "items": {"type": "number"}
+    "items": {"type": "number"},
+    "shape": {"nao", "nao"}
 }
 
 
 core_wavefunction["h_effective_b"] = {
     "type": "array",
     "description": "Beta-spin effective core (one-electron) Hamiltonian in the AO basis",
-    "items": {"type": "number"}
+    "items": {"type": "number"},
+    "shape": {"nao", "nao"}
 }

--- a/qcschema/dev/wavefunction/localized_wavefunction.py
+++ b/qcschema/dev/wavefunction/localized_wavefunction.py
@@ -1,0 +1,36 @@
+"""
+The complete list of localized-orbital SCF wavefunction quantities.
+"""
+
+localized_wavefunction = {}
+
+# Orbitals
+localized_wavefunction["localized_orbitals_a"] = {
+    "type": "array",
+    "description": "Localized alpha-spin orbitals",
+    "items": {"type": "number"}
+}
+
+
+localized_wavefunction["localized_orbitals_b"] = {
+    "type": "array",
+    "description": "Localized beta-spin orbitals",
+    "items": {"type": "number"}
+}
+
+
+# Fock matrix
+localized_wavefunction["localized_fock_a"] = {
+    "type": "array",
+    "description": "Alpha-spin Fock matrix in the localized molecular orbital basis",
+    "items": {"type": "number"}
+}
+
+
+localized_wavefunction["localized_fock_b"] = {
+    "type": "array",
+    "description": "Beta-spin Fock matrix in the localized molecular orbital basis",
+    "items": {"type": "number"}
+}
+
+# Note that localized density, eigenvalues, and occupations are not included since they are the same as the SCF density

--- a/qcschema/dev/wavefunction/localized_wavefunction.py
+++ b/qcschema/dev/wavefunction/localized_wavefunction.py
@@ -7,14 +7,14 @@ localized_wavefunction = {}
 # Orbitals
 localized_wavefunction["localized_orbitals_a"] = {
     "type": "array",
-    "description": "Localized alpha-spin orbitals",
+    "description": "Localized alpha-spin orbitals in the AO basis",
     "items": {"type": "number"}
 }
 
 
 localized_wavefunction["localized_orbitals_b"] = {
     "type": "array",
-    "description": "Localized beta-spin orbitals",
+    "description": "Localized beta-spin orbitals in the AO basis",
     "items": {"type": "number"}
 }
 

--- a/qcschema/dev/wavefunction/localized_wavefunction.py
+++ b/qcschema/dev/wavefunction/localized_wavefunction.py
@@ -8,7 +8,7 @@ localized_wavefunction = {}
 localized_wavefunction["localized_orbitals_a"] = {
     "type": "array",
     "description": "Localized alpha-spin orbitals in the AO basis. "
-                   "All nmo orbitals are included, even only a subset were localized.",
+                   "All nmo orbitals are included, even if only a subset were localized.",
     "items": {"type": "number"},
     "shape": {"nao", "nmo"}
 }
@@ -17,7 +17,7 @@ localized_wavefunction["localized_orbitals_a"] = {
 localized_wavefunction["localized_orbitals_b"] = {
     "type": "array",
     "description": "Localized beta-spin orbitals in the AO basis. "
-                   "All nmo orbitals are included, even only a subset were localized.",
+                   "All nmo orbitals are included, even if only a subset were localized.",
     "items": {"type": "number"},
     "shape": {"nao", "nmo"}
 }
@@ -27,7 +27,7 @@ localized_wavefunction["localized_orbitals_b"] = {
 localized_wavefunction["localized_fock_a"] = {
     "type": "array",
     "description": "Alpha-spin Fock matrix in the localized molecular orbital basis. "
-                   "All nmo orbitals are included, even only a subset were localized.",
+                   "All nmo orbitals are included, even if only a subset were localized.",
     "items": {"type": "number"},
     "shape": {"nmo", "nmo"}
 }
@@ -36,7 +36,7 @@ localized_wavefunction["localized_fock_a"] = {
 localized_wavefunction["localized_fock_b"] = {
     "type": "array",
     "description": "Beta-spin Fock matrix in the localized molecular orbital basis. "
-                   "All nmo orbitals are included, even only a subset were localized.",
+                   "All nmo orbitals are included, even if only a subset were localized.",
     "items": {"type": "number"},
     "shape": {"nmo", "nmo"}
 }

--- a/qcschema/dev/wavefunction/localized_wavefunction.py
+++ b/qcschema/dev/wavefunction/localized_wavefunction.py
@@ -15,7 +15,7 @@ localized_wavefunction["localized_orbitals_a"] = {
 
 localized_wavefunction["localized_orbitals_b"] = {
     "type": "array",
-    "description": "Localized beta-spin orbitals in the AO basis."
+    "description": "Localized beta-spin orbitals in the AO basis. "
                    "All N_AO orbitals are included, even only a subset were localized.",
     "items": {"type": "number"}
 }
@@ -24,7 +24,7 @@ localized_wavefunction["localized_orbitals_b"] = {
 # Fock matrix
 localized_wavefunction["localized_fock_a"] = {
     "type": "array",
-    "description": "Alpha-spin Fock matrix in the localized molecular orbital basis."
+    "description": "Alpha-spin Fock matrix in the localized molecular orbital basis. "
                    "All N_AO orbitals are included, even only a subset were localized.",
     "items": {"type": "number"}
 }
@@ -32,7 +32,7 @@ localized_wavefunction["localized_fock_a"] = {
 
 localized_wavefunction["localized_fock_b"] = {
     "type": "array",
-    "description": "Beta-spin Fock matrix in the localized molecular orbital basis."
+    "description": "Beta-spin Fock matrix in the localized molecular orbital basis. "
                    "All N_AO orbitals are included, even only a subset were localized.",
     "items": {"type": "number"}
 }

--- a/qcschema/dev/wavefunction/localized_wavefunction.py
+++ b/qcschema/dev/wavefunction/localized_wavefunction.py
@@ -8,16 +8,18 @@ localized_wavefunction = {}
 localized_wavefunction["localized_orbitals_a"] = {
     "type": "array",
     "description": "Localized alpha-spin orbitals in the AO basis. "
-                   "All N_AO orbitals are included, even only a subset were localized.",
-    "items": {"type": "number"}
+                   "All nmo orbitals are included, even only a subset were localized.",
+    "items": {"type": "number"},
+    "shape": {"nao", "nmo"}
 }
 
 
 localized_wavefunction["localized_orbitals_b"] = {
     "type": "array",
     "description": "Localized beta-spin orbitals in the AO basis. "
-                   "All N_AO orbitals are included, even only a subset were localized.",
-    "items": {"type": "number"}
+                   "All nmo orbitals are included, even only a subset were localized.",
+    "items": {"type": "number"},
+    "shape": {"nao", "nmo"}
 }
 
 
@@ -25,16 +27,18 @@ localized_wavefunction["localized_orbitals_b"] = {
 localized_wavefunction["localized_fock_a"] = {
     "type": "array",
     "description": "Alpha-spin Fock matrix in the localized molecular orbital basis. "
-                   "All N_AO orbitals are included, even only a subset were localized.",
-    "items": {"type": "number"}
+                   "All nmo orbitals are included, even only a subset were localized.",
+    "items": {"type": "number"},
+    "shape": {"nmo", "nmo"}
 }
 
 
 localized_wavefunction["localized_fock_b"] = {
     "type": "array",
     "description": "Beta-spin Fock matrix in the localized molecular orbital basis. "
-                   "All N_AO orbitals are included, even only a subset were localized.",
-    "items": {"type": "number"}
+                   "All nmo orbitals are included, even only a subset were localized.",
+    "items": {"type": "number"},
+    "shape": {"nmo", "nmo"}
 }
 
 # Note that localized density, eigenvalues, and occupations are not included since they are the same as the SCF density

--- a/qcschema/dev/wavefunction/localized_wavefunction.py
+++ b/qcschema/dev/wavefunction/localized_wavefunction.py
@@ -7,14 +7,16 @@ localized_wavefunction = {}
 # Orbitals
 localized_wavefunction["localized_orbitals_a"] = {
     "type": "array",
-    "description": "Localized alpha-spin orbitals in the AO basis",
+    "description": "Localized alpha-spin orbitals in the AO basis. "
+                   "All N_AO orbitals are included, even only a subset were localized.",
     "items": {"type": "number"}
 }
 
 
 localized_wavefunction["localized_orbitals_b"] = {
     "type": "array",
-    "description": "Localized beta-spin orbitals in the AO basis",
+    "description": "Localized beta-spin orbitals in the AO basis."
+                   "All N_AO orbitals are included, even only a subset were localized.",
     "items": {"type": "number"}
 }
 
@@ -22,14 +24,16 @@ localized_wavefunction["localized_orbitals_b"] = {
 # Fock matrix
 localized_wavefunction["localized_fock_a"] = {
     "type": "array",
-    "description": "Alpha-spin Fock matrix in the localized molecular orbital basis",
+    "description": "Alpha-spin Fock matrix in the localized molecular orbital basis."
+                   "All N_AO orbitals are included, even only a subset were localized.",
     "items": {"type": "number"}
 }
 
 
 localized_wavefunction["localized_fock_b"] = {
     "type": "array",
-    "description": "Beta-spin Fock matrix in the localized molecular orbital basis",
+    "description": "Beta-spin Fock matrix in the localized molecular orbital basis."
+                   "All N_AO orbitals are included, even only a subset were localized.",
     "items": {"type": "number"}
 }
 

--- a/qcschema/dev/wavefunction/result_wavefunction.py
+++ b/qcschema/dev/wavefunction/result_wavefunction.py
@@ -7,28 +7,28 @@ result_wavefunction = {}
 # Orbitals
 result_wavefunction["return_result_orbitals_a"] = {
     "type": "array",
-    "description": "The primary specified return alpha-spin orbitals",
+    "description": "The primary specified return alpha-spin orbitals in the AO basis",
     "items": {"type": "number"}
 }
 
 
 result_wavefunction["return_result_orbitals_b"] = {
     "type": "array",
-    "description": "The primary specified return beta-spin orbitals",
+    "description": "The primary specified return beta-spin orbitals in the AO basis",
     "items": {"type": "number"}
 }
 
 # Density
 result_wavefunction["return_result_density_a"] = {
     "type": "array",
-    "description": "The primary specified return alpha-spin density",
+    "description": "The primary specified return alpha-spin density in the AO basis",
     "items": {"type": "number"}
 }
 
 
 result_wavefunction["return_result_density_b"] = {
     "type": "array",
-    "description": "The primary specified return beta-spin density",
+    "description": "The primary specified return beta-spin density in the AO basis",
     "items": {"type": "number"}
 }
 
@@ -36,14 +36,14 @@ result_wavefunction["return_result_density_b"] = {
 # Fock matrix
 result_wavefunction["return_result_fock_a"] = {
     "type": "array",
-    "description": "The primary specified return alpha-spin Fock matrix",
+    "description": "The primary specified return alpha-spin Fock matrix in the AO basis",
     "items": {"type": "number"}
 }
 
 
 result_wavefunction["return_result_fock_b"] = {
     "type": "array",
-    "description": "The primary specified return beta-spin Fock matrix",
+    "description": "The primary specified return beta-spin Fock matrix in the AO basis",
     "items": {"type": "number"}
 }
 

--- a/qcschema/dev/wavefunction/result_wavefunction.py
+++ b/qcschema/dev/wavefunction/result_wavefunction.py
@@ -6,83 +6,63 @@ result_wavefunction = {}
 
 # Orbitals
 result_wavefunction["orbitals_a"] = {
-    "type": "array",
-    "description": "Alpha-spin orbitals in the AO basis of the primary return.",
-    "items": {"type": "number"},
-    "shape": {"nao", "nmo"}
+    "type": "string",
+    "description": "Alpha-spin orbitals in the AO basis of the primary return. "
 }
 
 
 result_wavefunction["orbitals_b"] = {
-    "type": "array",
-    "description": "Beta-spin orbitals in the AO basis of the primary return.",
-    "items": {"type": "number"},
-    "shape": {"nao", "nmo"}
+    "type": "string",
+    "description": "Beta-spin orbitals in the AO basis of the primary return."
 }
 
 # Density
 result_wavefunction["density_a"] = {
-    "type": "array",
-    "description": "Alpha-spin density in the AO basis of the primary return.",
-    "items": {"type": "number"},
-    "shape": {"nao", "nao"}
+    "type": "string",
+    "description": "Alpha-spin density in the AO basis of the primary return."
 }
 
 
 result_wavefunction["density_b"] = {
-    "type": "array",
-    "description": "Beta-spin density in the AO basis of the primary return.",
-    "items": {"type": "number"},
-    "shape": {"nao", "nao"}
+    "type": "string",
+    "description": "Beta-spin density in the AO basis of the primary return."
 }
 
 
 # Fock matrix
 result_wavefunction["fock_a"] = {
-    "type": "array",
-    "description": "Alpha-spin Fock matrix in the AO basis of the primary return.",
-    "items": {"type": "number"},
-    "shape": {"nao", "nao"}
+    "type": "string",
+    "description": "Alpha-spin Fock matrix in the AO basis of the primary return."
 }
 
 
 result_wavefunction["fock_b"] = {
-    "type": "array",
-    "description": "Beta-spin Fock matrix in the AO basis of the primary return.",
-    "items": {"type": "number"},
-    "shape": {"nao", "nao"}
+    "type": "string",
+    "description": "Beta-spin Fock matrix in the AO basis of the primary return."
 }
 
 
 # Eigenvalues
 result_wavefunction["eigenvalues_a"] = {
-    "type": "array",
-    "description": "Alpha-spin orbital eigenvalues of the primary return.",
-    "items": {"type": "number"},
-    "shape": {"nmo"}
+    "type": "string",
+    "description": "Alpha-spin orbital eigenvalues of the primary return."
 }
 
 
 result_wavefunction["eigenvalues_b"] = {
-    "type": "array",
-    "description": "Beta-spin orbital eigenvalues of the primary return.",
-    "items": {"type": "number"},
-    "shape": {"nmo"}
+    "type": "string",
+    "description": "Beta-spin orbital eigenvalues of the primary return."
 }
 
 
 # Occupations
 result_wavefunction["occupations_a"] = {
-    "type": "array",
-    "description": "Alpha-spin orbital occupations of the primary return.",
-    "items": {"type": "number"},
-    "shape": {"nmo"}
+    "type": "string",
+    "description": "Alpha-spin orbital occupations of the primary return."
 }
 
 
 result_wavefunction["occupations_b"] = {
-    "type": "array",
-    "description": "Beta-spin orbital occupations of the primary return.",
-    "items": {"type": "number"},
-    "shape": {"nmo"}
+    "type": "string",
+    "description": "Beta-spin orbital occupations of the primary return."
 }

--- a/qcschema/dev/wavefunction/result_wavefunction.py
+++ b/qcschema/dev/wavefunction/result_wavefunction.py
@@ -1,0 +1,78 @@
+"""
+The primary specified return  wavefunction quantities.
+"""
+
+result_wavefunction = {}
+
+# Orbitals
+result_wavefunction["return_result_orbitals_a"] = {
+    "type": "array",
+    "description": "The primary specified return alpha-spin orbitals",
+    "items": {"type": "number"}
+}
+
+
+result_wavefunction["return_result_orbitals_b"] = {
+    "type": "array",
+    "description": "The primary specified return beta-spin orbitals",
+    "items": {"type": "number"}
+}
+
+# Density
+result_wavefunction["return_result_density_a"] = {
+    "type": "array",
+    "description": "The primary specified return alpha-spin density",
+    "items": {"type": "number"}
+}
+
+
+result_wavefunction["return_result_density_b"] = {
+    "type": "array",
+    "description": "The primary specified return beta-spin density",
+    "items": {"type": "number"}
+}
+
+
+# Fock matrix
+result_wavefunction["return_result_fock_a"] = {
+    "type": "array",
+    "description": "The primary specified return alpha-spin Fock matrix",
+    "items": {"type": "number"}
+}
+
+
+result_wavefunction["return_result_fock_b"] = {
+    "type": "array",
+    "description": "The primary specified return beta-spin Fock matrix",
+    "items": {"type": "number"}
+}
+
+
+# Eigenvalues
+result_wavefunction["return_result_eigenvalues_a"] = {
+    "type": "array",
+    "description": "The primary specified return alpha-spin orbital eigenvalues",
+    "items": {"type": "number"}
+}
+
+
+result_wavefunction["return_result_eigenvalues_b"] = {
+    "type": "array",
+    "description": "SCF beta-spin orbital eigenvalues",
+    "items": {"type": "number"}
+}
+
+
+# Occupations
+result_wavefunction["return_result_occupations_a"] = {
+    "type": "array",
+    "description": "SCF alpha-spin orbital occupations",
+    "items": {"type": "number"}
+}
+
+
+result_wavefunction["return_result_occupations_b"] = {
+    "type": "array",
+    "description": "SCF beta-spin orbital occupations",
+    "items": {"type": "number"}
+}

--- a/qcschema/dev/wavefunction/result_wavefunction.py
+++ b/qcschema/dev/wavefunction/result_wavefunction.py
@@ -5,84 +5,84 @@ The primary specified return  wavefunction quantities.
 result_wavefunction = {}
 
 # Orbitals
-result_wavefunction["return_result_orbitals_a"] = {
+result_wavefunction["orbitals_a"] = {
     "type": "array",
-    "description": "The primary specified return alpha-spin orbitals in the AO basis",
+    "description": "Alpha-spin orbitals in the AO basis of the primary return.",
     "items": {"type": "number"},
     "shape": {"nao", "nmo"}
 }
 
 
-result_wavefunction["return_result_orbitals_b"] = {
+result_wavefunction["orbitals_b"] = {
     "type": "array",
-    "description": "The primary specified return beta-spin orbitals in the AO basis",
+    "description": "Beta-spin orbitals in the AO basis of the primary return.",
     "items": {"type": "number"},
     "shape": {"nao", "nmo"}
 }
 
 # Density
-result_wavefunction["return_result_density_a"] = {
+result_wavefunction["density_a"] = {
     "type": "array",
-    "description": "The primary specified return alpha-spin density in the AO basis",
+    "description": "Alpha-spin density in the AO basis of the primary return.",
     "items": {"type": "number"},
     "shape": {"nao", "nao"}
 }
 
 
-result_wavefunction["return_result_density_b"] = {
+result_wavefunction["density_b"] = {
     "type": "array",
-    "description": "The primary specified return beta-spin density in the AO basis",
+    "description": "Beta-spin density in the AO basis of the primary return.",
     "items": {"type": "number"},
     "shape": {"nao", "nao"}
 }
 
 
 # Fock matrix
-result_wavefunction["return_result_fock_a"] = {
+result_wavefunction["fock_a"] = {
     "type": "array",
-    "description": "The primary specified return alpha-spin Fock matrix in the AO basis",
+    "description": "Alpha-spin Fock matrix in the AO basis of the primary return.",
     "items": {"type": "number"},
     "shape": {"nao", "nao"}
 }
 
 
-result_wavefunction["return_result_fock_b"] = {
+result_wavefunction["fock_b"] = {
     "type": "array",
-    "description": "The primary specified return beta-spin Fock matrix in the AO basis",
+    "description": "Beta-spin Fock matrix in the AO basis of the primary return.",
     "items": {"type": "number"},
     "shape": {"nao", "nao"}
 }
 
 
 # Eigenvalues
-result_wavefunction["return_result_eigenvalues_a"] = {
+result_wavefunction["eigenvalues_a"] = {
     "type": "array",
-    "description": "The primary specified return alpha-spin orbital eigenvalues",
+    "description": "Alpha-spin orbital eigenvalues of the primary return.",
     "items": {"type": "number"},
     "shape": {"nmo"}
 }
 
 
-result_wavefunction["return_result_eigenvalues_b"] = {
+result_wavefunction["eigenvalues_b"] = {
     "type": "array",
-    "description": "SCF beta-spin orbital eigenvalues",
+    "description": "Beta-spin orbital eigenvalues of the primary return.",
     "items": {"type": "number"},
     "shape": {"nmo"}
 }
 
 
 # Occupations
-result_wavefunction["return_result_occupations_a"] = {
+result_wavefunction["occupations_a"] = {
     "type": "array",
-    "description": "SCF alpha-spin orbital occupations",
+    "description": "Alpha-spin orbital occupations of the primary return.",
     "items": {"type": "number"},
     "shape": {"nmo"}
 }
 
 
-result_wavefunction["return_result_occupations_b"] = {
+result_wavefunction["occupations_b"] = {
     "type": "array",
-    "description": "SCF beta-spin orbital occupations",
+    "description": "Beta-spin orbital occupations of the primary return.",
     "items": {"type": "number"},
     "shape": {"nmo"}
 }

--- a/qcschema/dev/wavefunction/result_wavefunction.py
+++ b/qcschema/dev/wavefunction/result_wavefunction.py
@@ -8,28 +8,32 @@ result_wavefunction = {}
 result_wavefunction["return_result_orbitals_a"] = {
     "type": "array",
     "description": "The primary specified return alpha-spin orbitals in the AO basis",
-    "items": {"type": "number"}
+    "items": {"type": "number"},
+    "shape": {"nao", "nmo"}
 }
 
 
 result_wavefunction["return_result_orbitals_b"] = {
     "type": "array",
     "description": "The primary specified return beta-spin orbitals in the AO basis",
-    "items": {"type": "number"}
+    "items": {"type": "number"},
+    "shape": {"nao", "nmo"}
 }
 
 # Density
 result_wavefunction["return_result_density_a"] = {
     "type": "array",
     "description": "The primary specified return alpha-spin density in the AO basis",
-    "items": {"type": "number"}
+    "items": {"type": "number"},
+    "shape": {"nao", "nao"}
 }
 
 
 result_wavefunction["return_result_density_b"] = {
     "type": "array",
     "description": "The primary specified return beta-spin density in the AO basis",
-    "items": {"type": "number"}
+    "items": {"type": "number"},
+    "shape": {"nao", "nao"}
 }
 
 
@@ -37,14 +41,16 @@ result_wavefunction["return_result_density_b"] = {
 result_wavefunction["return_result_fock_a"] = {
     "type": "array",
     "description": "The primary specified return alpha-spin Fock matrix in the AO basis",
-    "items": {"type": "number"}
+    "items": {"type": "number"},
+    "shape": {"nao", "nao"}
 }
 
 
 result_wavefunction["return_result_fock_b"] = {
     "type": "array",
     "description": "The primary specified return beta-spin Fock matrix in the AO basis",
-    "items": {"type": "number"}
+    "items": {"type": "number"},
+    "shape": {"nao", "nao"}
 }
 
 
@@ -52,14 +58,16 @@ result_wavefunction["return_result_fock_b"] = {
 result_wavefunction["return_result_eigenvalues_a"] = {
     "type": "array",
     "description": "The primary specified return alpha-spin orbital eigenvalues",
-    "items": {"type": "number"}
+    "items": {"type": "number"},
+    "shape": {"nmo"}
 }
 
 
 result_wavefunction["return_result_eigenvalues_b"] = {
     "type": "array",
     "description": "SCF beta-spin orbital eigenvalues",
-    "items": {"type": "number"}
+    "items": {"type": "number"},
+    "shape": {"nmo"}
 }
 
 
@@ -67,12 +75,14 @@ result_wavefunction["return_result_eigenvalues_b"] = {
 result_wavefunction["return_result_occupations_a"] = {
     "type": "array",
     "description": "SCF alpha-spin orbital occupations",
-    "items": {"type": "number"}
+    "items": {"type": "number"},
+    "shape": {"nmo"}
 }
 
 
 result_wavefunction["return_result_occupations_b"] = {
     "type": "array",
     "description": "SCF beta-spin orbital occupations",
-    "items": {"type": "number"}
+    "items": {"type": "number"},
+    "shape": {"nmo"}
 }

--- a/qcschema/dev/wavefunction/scf_wavefunction.py
+++ b/qcschema/dev/wavefunction/scf_wavefunction.py
@@ -8,28 +8,32 @@ scf_wavefunction = {}
 scf_wavefunction["scf_orbitals_a"] = {
     "type": "array",
     "description": "SCF alpha-spin orbitals in the AO basis",
-    "items": {"type": "number"}
+    "items": {"type": "number"},
+    "shape": {"nao", "nmo"}
 }
 
 
 scf_wavefunction["scf_orbitals_b"] = {
     "type": "array",
     "description": "SCF beta-spin orbitals in the AO basis",
-    "items": {"type": "number"}
+    "items": {"type": "number"},
+    "shape": {"nao", "nmo"}
 }
 
 # Density
 scf_wavefunction["scf_density_a"] = {
     "type": "array",
     "description": "SCF alpha-spin density in the AO basis",
-    "items": {"type": "number"}
+    "items": {"type": "number"},
+    "shape": {"nao", "nao"}
 }
 
 
 scf_wavefunction["scf_density_b"] = {
     "type": "array",
     "description": "SCF beta-spin density in the AO basis",
-    "items": {"type": "number"}
+    "items": {"type": "number"},
+    "shape": {"nao", "nao"}
 }
 
 
@@ -37,14 +41,16 @@ scf_wavefunction["scf_density_b"] = {
 scf_wavefunction["scf_fock_a"] = {
     "type": "array",
     "description": "SCF alpha-spin Fock matrix in the AO basis",
-    "items": {"type": "number"}
+    "items": {"type": "number"},
+    "shape": {"nao", "nao"}
 }
 
 
 scf_wavefunction["scf_fock_b"] = {
     "type": "array",
     "description": "SCF beta-spin Fock matrix in the AO basis",
-    "items": {"type": "number"}
+    "items": {"type": "number"},
+    "shape": {"nao", "nao"}
 }
 
 
@@ -52,14 +58,16 @@ scf_wavefunction["scf_fock_b"] = {
 scf_wavefunction["scf_eigenvalues_a"] = {
     "type": "array",
     "description": "SCF alpha-spin orbital eigenvalues",
-    "items": {"type": "number"}
+    "items": {"type": "number"},
+    "shape": {"nmo"}
 }
 
 
 scf_wavefunction["scf_eigenvalues_b"] = {
     "type": "array",
     "description": "SCF beta-spin orbital eigenvalues",
-    "items": {"type": "number"}
+    "items": {"type": "number"},
+    "shape": {"nmo"}
 }
 
 
@@ -67,12 +75,14 @@ scf_wavefunction["scf_eigenvalues_b"] = {
 scf_wavefunction["scf_occupations_a"] = {
     "type": "array",
     "description": "SCF alpha-spin orbital occupations",
-    "items": {"type": "number"}
+    "items": {"type": "number"},
+    "shape": {"nmo"}
 }
 
 
 scf_wavefunction["scf_occupations_b"] = {
     "type": "array",
     "description": "SCF beta-spin orbital occupations",
-    "items": {"type": "number"}
+    "items": {"type": "number"},
+    "shape": {"nmo"}
 }

--- a/qcschema/dev/wavefunction/scf_wavefunction.py
+++ b/qcschema/dev/wavefunction/scf_wavefunction.py
@@ -7,28 +7,28 @@ scf_wavefunction = {}
 # Orbitals
 scf_wavefunction["scf_orbitals_a"] = {
     "type": "array",
-    "description": "SCF alpha-spin orbitals",
+    "description": "SCF alpha-spin orbitals in the AO basis",
     "items": {"type": "number"}
 }
 
 
 scf_wavefunction["scf_orbitals_b"] = {
     "type": "array",
-    "description": "SCF beta-spin orbitals",
+    "description": "SCF beta-spin orbitals in the AO basis",
     "items": {"type": "number"}
 }
 
 # Density
 scf_wavefunction["scf_density_a"] = {
     "type": "array",
-    "description": "SCF alpha-spin density",
+    "description": "SCF alpha-spin density in the AO basis",
     "items": {"type": "number"}
 }
 
 
 scf_wavefunction["scf_density_b"] = {
     "type": "array",
-    "description": "SCF beta-spin density",
+    "description": "SCF beta-spin density in the AO basis",
     "items": {"type": "number"}
 }
 
@@ -36,14 +36,14 @@ scf_wavefunction["scf_density_b"] = {
 # Fock matrix
 scf_wavefunction["scf_fock_a"] = {
     "type": "array",
-    "description": "SCF alpha-spin Fock matrix",
+    "description": "SCF alpha-spin Fock matrix in the AO basis",
     "items": {"type": "number"}
 }
 
 
 scf_wavefunction["scf_fock_b"] = {
     "type": "array",
-    "description": "SCF beta-spin Fock matrix",
+    "description": "SCF beta-spin Fock matrix in the AO basis",
     "items": {"type": "number"}
 }
 

--- a/qcschema/dev/wavefunction/scf_wavefunction.py
+++ b/qcschema/dev/wavefunction/scf_wavefunction.py
@@ -1,0 +1,78 @@
+"""
+The complete list of SCF level wavefunction quantities.
+"""
+
+scf_wavefunction = {}
+
+# Orbitals
+scf_wavefunction["scf_orbitals_a"] = {
+    "type": "array",
+    "description": "SCF alpha-spin orbitals",
+    "items": {"type": "number"}
+}
+
+
+scf_wavefunction["scf_orbitals_b"] = {
+    "type": "array",
+    "description": "SCF beta-spin orbitals",
+    "items": {"type": "number"}
+}
+
+# Density
+scf_wavefunction["scf_density_a"] = {
+    "type": "array",
+    "description": "SCF alpha-spin density",
+    "items": {"type": "number"}
+}
+
+
+scf_wavefunction["scf_density_b"] = {
+    "type": "array",
+    "description": "SCF beta-spin density",
+    "items": {"type": "number"}
+}
+
+
+# Fock matrix
+scf_wavefunction["scf_fock_a"] = {
+    "type": "array",
+    "description": "SCF alpha-spin Fock matrix",
+    "items": {"type": "number"}
+}
+
+
+scf_wavefunction["scf_fock_b"] = {
+    "type": "array",
+    "description": "SCF beta-spin Fock matrix",
+    "items": {"type": "number"}
+}
+
+
+# Eigenvalues
+scf_wavefunction["scf_eigenvalues_a"] = {
+    "type": "array",
+    "description": "SCF alpha-spin orbital eigenvalues",
+    "items": {"type": "number"}
+}
+
+
+scf_wavefunction["scf_eigenvalues_b"] = {
+    "type": "array",
+    "description": "SCF beta-spin orbital eigenvalues",
+    "items": {"type": "number"}
+}
+
+
+# Occupations
+scf_wavefunction["scf_occupations_a"] = {
+    "type": "array",
+    "description": "SCF alpha-spin orbital occupations",
+    "items": {"type": "number"}
+}
+
+
+scf_wavefunction["scf_occupations_b"] = {
+    "type": "array",
+    "description": "SCF beta-spin orbital occupations",
+    "items": {"type": "number"}
+}

--- a/qcschema/dev/wavefunction/scf_wavefunction.py
+++ b/qcschema/dev/wavefunction/scf_wavefunction.py
@@ -7,7 +7,7 @@ scf_wavefunction = {}
 # Orbitals
 scf_wavefunction["scf_orbitals_a"] = {
     "type": "array",
-    "description": "SCF alpha-spin orbitals in the AO basis",
+    "description": "SCF alpha-spin orbitals in the AO basis.",
     "items": {"type": "number"},
     "shape": {"nao", "nmo"}
 }
@@ -15,7 +15,7 @@ scf_wavefunction["scf_orbitals_a"] = {
 
 scf_wavefunction["scf_orbitals_b"] = {
     "type": "array",
-    "description": "SCF beta-spin orbitals in the AO basis",
+    "description": "SCF beta-spin orbitals in the AO basis.",
     "items": {"type": "number"},
     "shape": {"nao", "nmo"}
 }
@@ -23,7 +23,7 @@ scf_wavefunction["scf_orbitals_b"] = {
 # Density
 scf_wavefunction["scf_density_a"] = {
     "type": "array",
-    "description": "SCF alpha-spin density in the AO basis",
+    "description": "SCF alpha-spin density in the AO basis.",
     "items": {"type": "number"},
     "shape": {"nao", "nao"}
 }
@@ -31,7 +31,7 @@ scf_wavefunction["scf_density_a"] = {
 
 scf_wavefunction["scf_density_b"] = {
     "type": "array",
-    "description": "SCF beta-spin density in the AO basis",
+    "description": "SCF beta-spin density in the AO basis.",
     "items": {"type": "number"},
     "shape": {"nao", "nao"}
 }
@@ -40,7 +40,7 @@ scf_wavefunction["scf_density_b"] = {
 # Fock matrix
 scf_wavefunction["scf_fock_a"] = {
     "type": "array",
-    "description": "SCF alpha-spin Fock matrix in the AO basis",
+    "description": "SCF alpha-spin Fock matrix in the AO basis.",
     "items": {"type": "number"},
     "shape": {"nao", "nao"}
 }
@@ -48,7 +48,39 @@ scf_wavefunction["scf_fock_a"] = {
 
 scf_wavefunction["scf_fock_b"] = {
     "type": "array",
-    "description": "SCF beta-spin Fock matrix in the AO basis",
+    "description": "SCF beta-spin Fock matrix in the AO basis.",
+    "items": {"type": "number"},
+    "shape": {"nao", "nao"}
+}
+
+
+scf_wavefunction["scf_coulomb_a"] = {
+    "type": "array",
+    "description": "SCF alpha-spin Coulomb matrix in the AO basis.",
+    "items": {"type": "number"},
+    "shape": {"nao", "nao"}
+}
+
+
+scf_wavefunction["scf_coulomb_b"] = {
+    "type": "array",
+    "description": "SCF beta-spin Coulomb matrix in the AO basis.",
+    "items": {"type": "number"},
+    "shape": {"nao", "nao"}
+}
+
+
+scf_wavefunction["scf_exchange_a"] = {
+    "type": "array",
+    "description": "SCF alpha-spin exchange matrix in the AO basis.",
+    "items": {"type": "number"},
+    "shape": {"nao", "nao"}
+}
+
+
+scf_wavefunction["scf_exchange_b"] = {
+    "type": "array",
+    "description": "SCF beta-spin exchange matrix in the AO basis.",
     "items": {"type": "number"},
     "shape": {"nao", "nao"}
 }
@@ -57,7 +89,7 @@ scf_wavefunction["scf_fock_b"] = {
 # Eigenvalues
 scf_wavefunction["scf_eigenvalues_a"] = {
     "type": "array",
-    "description": "SCF alpha-spin orbital eigenvalues",
+    "description": "SCF alpha-spin orbital eigenvalues.",
     "items": {"type": "number"},
     "shape": {"nmo"}
 }
@@ -65,7 +97,7 @@ scf_wavefunction["scf_eigenvalues_a"] = {
 
 scf_wavefunction["scf_eigenvalues_b"] = {
     "type": "array",
-    "description": "SCF beta-spin orbital eigenvalues",
+    "description": "SCF beta-spin orbital eigenvalues.",
     "items": {"type": "number"},
     "shape": {"nmo"}
 }
@@ -74,7 +106,7 @@ scf_wavefunction["scf_eigenvalues_b"] = {
 # Occupations
 scf_wavefunction["scf_occupations_a"] = {
     "type": "array",
-    "description": "SCF alpha-spin orbital occupations",
+    "description": "SCF alpha-spin orbital occupations.",
     "items": {"type": "number"},
     "shape": {"nmo"}
 }
@@ -82,7 +114,8 @@ scf_wavefunction["scf_occupations_a"] = {
 
 scf_wavefunction["scf_occupations_b"] = {
     "type": "array",
-    "description": "SCF beta-spin orbital occupations",
+    "description": "SCF beta-spin orbital occupations.",
     "items": {"type": "number"},
     "shape": {"nmo"}
 }
+

--- a/qcschema/dev/wavefunction/wavefunction_base.py
+++ b/qcschema/dev/wavefunction/wavefunction_base.py
@@ -1,0 +1,25 @@
+"""
+The base file for QC Schema properties.
+"""
+
+from .result_wavefunction import result_wavefunction
+from .scf_wavefunction import scf_wavefunction
+from .localized_wavefunction import localized_wavefunction
+from ..basis import basis
+
+output_wavefunction = {
+    "type": "object",
+    "properties": {
+        "basis": basis
+    },
+    "description": "Wavefunction properties resulting from a computation",
+    "additionalProperties": False,
+    "required": ["basis"]
+}
+
+# Update new keys
+output_wavefunction["properties"].update(result_wavefunction)
+output_wavefunction["properties"].update(scf_wavefunction)
+output_wavefunction["properties"].update(localized_wavefunction)
+
+

--- a/qcschema/dev/wavefunction/wavefunction_base.py
+++ b/qcschema/dev/wavefunction/wavefunction_base.py
@@ -5,6 +5,7 @@ The base file for QC Schema properties.
 from .result_wavefunction import result_wavefunction
 from .scf_wavefunction import scf_wavefunction
 from .localized_wavefunction import localized_wavefunction
+from .core_wavefunction import core_wavefunction
 from ..basis import basis
 
 output_wavefunction = {
@@ -12,7 +13,8 @@ output_wavefunction = {
     "properties": {
         "basis": basis
     },
-    "description": "Wavefunction properties resulting from a computation",
+    "description": "Wavefunction properties resulting from a computation."
+                   "Matrix quantities are stored in column-major order.",
     "additionalProperties": False,
     "required": ["basis"]
 }
@@ -21,5 +23,4 @@ output_wavefunction = {
 output_wavefunction["properties"].update(result_wavefunction)
 output_wavefunction["properties"].update(scf_wavefunction)
 output_wavefunction["properties"].update(localized_wavefunction)
-
-
+output_wavefunction["properties"].update(core_wavefunction)

--- a/tests/basis/waterZr_energy_B3LYP_STO3G_DEF2_input.json
+++ b/tests/basis/waterZr_energy_B3LYP_STO3G_DEF2_input.json
@@ -29,6 +29,7 @@
   "model": {
     "method": "B3LYP",
     "basis": {
+      "name": "Mixed Def2-TZVP/STO-3G",
       "description": "STO-3G on all Hydrogen and Oxygen, Def2-TZVP on Zr",
       "basis_data": {
         "bs_sto3g_h": {

--- a/tests/basis/waterZr_energy_B3LYP_STO3G_DEF2_input.json
+++ b/tests/basis/waterZr_energy_B3LYP_STO3G_DEF2_input.json
@@ -31,7 +31,7 @@
     "basis": {
       "name": "Mixed Def2-TZVP/STO-3G",
       "description": "STO-3G on all Hydrogen and Oxygen, Def2-TZVP on Zr",
-      "basis_data": {
+      "center_data": {
         "bs_sto3g_h": {
           "electron_shells": [
             {
@@ -380,7 +380,7 @@
           ]
         }
       },
-      "basis_atom_map": [
+      "atom_map": [
         "bs_sto3g_o",
         "bs_sto3g_h",
         "bs_sto3g_h",

--- a/tests/basis/water_energy_B3LYP_631G_input.json
+++ b/tests/basis/water_energy_B3LYP_631G_input.json
@@ -27,7 +27,7 @@
     "basis": {
       "name": "6-31G",
       "description": "6-31G on all Hydrogen and Oxygen atoms",
-      "basis_data": {
+      "center_data": {
         "bs_631g_h": {
           "electron_shells": [
             {
@@ -135,7 +135,7 @@
           ]
         }
       },
-      "basis_atom_map": [
+      "atom_map": [
         "bs_631g_o",
         "bs_631g_h",
         "bs_631g_h"

--- a/tests/basis/water_energy_B3LYP_631G_input.json
+++ b/tests/basis/water_energy_B3LYP_631G_input.json
@@ -25,6 +25,7 @@
   "model": {
     "method": "B3LYP",
     "basis": {
+      "name": "6-31G",
       "description": "6-31G on all Hydrogen and Oxygen atoms",
       "basis_data": {
         "bs_631g_h": {

--- a/tests/output_failures/wavefunction_basis_name.json
+++ b/tests/output_failures/wavefunction_basis_name.json
@@ -1,0 +1,59 @@
+{
+  "schema_name": "qc_schema_output",
+  "schema_version": 1,
+  "molecule": {
+    "schema_name": "qcschema_molecule",
+    "schema_version": 2,
+    "geometry": [
+      0.0,
+      0.0,
+      -0.1294769411935893,
+      0.0,
+      -1.494187339479985,
+      1.0274465079245698,
+      0.0,
+      1.494187339479985,
+      1.0274465079245698
+    ],
+    "symbols": [
+      "O",
+      "H",
+      "H"
+    ]
+  },
+  "driver": "energy",
+  "model": {
+    "method": "B3LYP",
+    "basis": "cc-pVDZ"
+  },
+  "keywords": {},
+  "provenance": {
+    "creator": "QM Program",
+    "version": "1.1",
+    "routine": "module.json.run_json"
+  },
+  "return_result": -76.4187620271478,
+  "success": true,
+  "properties": {
+    "calcinfo_nbasis": 24,
+    "calcinfo_nmo": 24,
+    "calcinfo_nalpha": 5,
+    "calcinfo_nbeta": 5,
+    "calcinfo_natom": 3,
+    "return_energy": -76.4187620271478,
+    "scf_one_electron_energy": -122.5182981454265,
+    "scf_two_electron_energy": 44.844942513688004,
+    "nuclear_repulsion_energy": 8.80146205625184,
+    "scf_dipole_moment": [
+      0.0,
+      0.0,
+      1.925357619589245
+    ],
+    "scf_iterations": 6,
+    "scf_total_energy": -76.4187620271478,
+    "scf_xc_energy": -7.546868451661161
+  },
+  "wavefunction": {
+    "basis": "cc-pVDZ"
+  }
+}

--- a/tests/output_failures/wavefunction_missing_basis.json
+++ b/tests/output_failures/wavefunction_missing_basis.json
@@ -1,0 +1,57 @@
+{
+  "schema_name": "qc_schema_output",
+  "schema_version": 1,
+  "molecule": {
+    "schema_name": "qcschema_molecule",
+    "schema_version": 2,
+    "geometry": [
+      0.0,
+      0.0,
+      -0.1294769411935893,
+      0.0,
+      -1.494187339479985,
+      1.0274465079245698,
+      0.0,
+      1.494187339479985,
+      1.0274465079245698
+    ],
+    "symbols": [
+      "O",
+      "H",
+      "H"
+    ]
+  },
+  "driver": "energy",
+  "model": {
+    "method": "B3LYP",
+    "basis": "cc-pVDZ"
+  },
+  "keywords": {},
+  "provenance": {
+    "creator": "QM Program",
+    "version": "1.1",
+    "routine": "module.json.run_json"
+  },
+  "return_result": -76.4187620271478,
+  "success": true,
+  "properties": {
+    "calcinfo_nbasis": 24,
+    "calcinfo_nmo": 24,
+    "calcinfo_nalpha": 5,
+    "calcinfo_nbeta": 5,
+    "calcinfo_natom": 3,
+    "return_energy": -76.4187620271478,
+    "scf_one_electron_energy": -122.5182981454265,
+    "scf_two_electron_energy": 44.844942513688004,
+    "nuclear_repulsion_energy": 8.80146205625184,
+    "scf_dipole_moment": [
+      0.0,
+      0.0,
+      1.925357619589245
+    ],
+    "scf_iterations": 6,
+    "scf_total_energy": -76.4187620271478,
+    "scf_xc_energy": -7.546868451661161
+  },
+  "wavefunction": {}
+}

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -42,3 +42,16 @@ def test_simple_basis_input(version, testfile):
 
     example = test_helpers.get_test(testfile)
     qcschema.validate(example, "input")
+
+
+
+### Test wavefunction outputs
+wavefunction_output = test_helpers.list_tests("wavefunction", matcher="output")
+
+# Loop over all tests that should pass the tests
+@pytest.mark.parametrize("testfile", wavefunction_output[0], ids=wavefunction_output[1])
+@pytest.mark.parametrize("version", qcschema.list_versions("output"))
+def test_wavefunction_output(version, testfile):
+
+    example = test_helpers.get_test(testfile)
+    qcschema.validate(example, "output")

--- a/tests/wavefunction/water_output.json
+++ b/tests/wavefunction/water_output.json
@@ -57,7 +57,7 @@
     "basis": {
       "name": "6-31G",
       "description": "6-31G on all Hydrogen and Oxygen atoms",
-      "basis_data": {
+      "center_data": {
         "bs_631g_h": {
           "electron_shells": [
             {
@@ -165,7 +165,7 @@
           ]
         }
       },
-      "basis_atom_map": [
+      "atom_map": [
         "bs_631g_o",
         "bs_631g_h",
         "bs_631g_h"

--- a/tests/wavefunction/water_output.json
+++ b/tests/wavefunction/water_output.json
@@ -55,6 +55,7 @@
   },
   "wavefunction": {
     "basis": {
+      "name": "6-31G",
       "description": "6-31G on all Hydrogen and Oxygen atoms",
       "basis_data": {
         "bs_631g_h": {

--- a/tests/wavefunction/water_output.json
+++ b/tests/wavefunction/water_output.json
@@ -1,0 +1,174 @@
+{
+  "schema_name": "qc_schema_output",
+  "schema_version": 1,
+  "molecule": {
+    "schema_name": "qcschema_molecule",
+    "schema_version": 2,
+    "geometry": [
+      0.0,
+      0.0,
+      -0.1294769411935893,
+      0.0,
+      -1.494187339479985,
+      1.0274465079245698,
+      0.0,
+      1.494187339479985,
+      1.0274465079245698
+    ],
+    "symbols": [
+      "O",
+      "H",
+      "H"
+    ]
+  },
+  "driver": "energy",
+  "model": {
+    "method": "B3LYP",
+    "basis": "cc-pVDZ"
+  },
+  "keywords": {},
+  "provenance": {
+    "creator": "QM Program",
+    "version": "1.1",
+    "routine": "module.json.run_json"
+  },
+  "return_result": -76.4187620271478,
+  "success": true,
+  "properties": {
+    "calcinfo_nbasis": 24,
+    "calcinfo_nmo": 24,
+    "calcinfo_nalpha": 5,
+    "calcinfo_nbeta": 5,
+    "calcinfo_natom": 3,
+    "return_energy": -76.4187620271478,
+    "scf_one_electron_energy": -122.5182981454265,
+    "scf_two_electron_energy": 44.844942513688004,
+    "nuclear_repulsion_energy": 8.80146205625184,
+    "scf_dipole_moment": [
+      0.0,
+      0.0,
+      1.925357619589245
+    ],
+    "scf_iterations": 6,
+    "scf_total_energy": -76.4187620271478,
+    "scf_xc_energy": -7.546868451661161
+  },
+  "wavefunction": {
+    "basis": {
+      "description": "6-31G on all Hydrogen and Oxygen atoms",
+      "basis_data": {
+        "bs_631g_h": {
+          "electron_shells": [
+            {
+              "harmonic_type": "spherical",
+              "angular_momentum": [
+                0
+              ],
+              "exponents": [
+                "18.731137",
+                "2.8253944",
+                "0.6401217"
+              ],
+              "coefficients": [
+                [
+                  "0.0334946",
+                  "0.2347269",
+                  "0.8137573"
+                ]
+              ]
+            },
+            {
+              "harmonic_type": "spherical",
+              "angular_momentum": [
+                0
+              ],
+              "exponents": [
+                "0.1612778"
+              ],
+              "coefficients": [
+                [
+                  "1.0000000"
+                ]
+              ]
+            }
+          ]
+        },
+        "bs_631g_o": {
+          "electron_shells": [
+            {
+              "harmonic_type": "spherical",
+              "angular_momentum": [
+                0
+              ],
+              "exponents": [
+                "5484.6717000",
+                "825.2349500",
+                "188.0469600",
+                "52.9645000",
+                "16.8975700",
+                "5.7996353"
+              ],
+              "coefficients": [
+                [
+                  "0.0018311",
+                  "0.0139501",
+                  "0.0684451",
+                  "0.2327143",
+                  "0.4701930",
+                  "0.3585209"
+                ]
+              ]
+            },
+            {
+              "harmonic_type": "spherical",
+              "angular_momentum": [
+                0,
+                1
+              ],
+              "exponents": [
+                "15.5396160",
+                "3.5999336",
+                "1.0137618"
+              ],
+              "coefficients": [
+                [
+                  "-0.1107775",
+                  "-0.1480263",
+                  "1.1307670"
+                ],
+                [
+                  "0.0708743",
+                  "0.3397528",
+                  "0.7271586"
+                ]
+              ]
+            },
+            {
+              "harmonic_type": "spherical",
+              "angular_momentum": [
+                0,
+                1
+              ],
+              "exponents": [
+                "0.2700058"
+              ],
+              "coefficients": [
+                [
+                  "1.0000000"
+                ],
+                [
+                  "1.0000000"
+                ]
+              ]
+            }
+          ]
+        }
+      },
+      "basis_atom_map": [
+        "bs_631g_o",
+        "bs_631g_h",
+        "bs_631g_h"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Description
This PR adds (one-electron) output wavefunction quantities, such as the Fock matrix, orbitals, density, orbital eigenvalues, and orbitals occupations. So far in this PR are:

- SCF
- Localized orbitals
- "Return result" 
- (Effective) core Hamiltonian

Obvious things to add include:

- [x] ~MP2, CC* quantities~
- [x] ~MCSCF and CAS quantities~
- [x] More tests

This PR partially addresses issue #63 (notably excluding input for wavefunction quantities). It implements some decisions made therein, including:

- no effort is made to increase compression (e.g. using binary data or matrix symmetry)
- `wavefunction` is a top-level field
- basis sets must be fully specified in `wavefunction` if `wavefunction` is present
- alpha and beta quantities are duplicated even for restricted reference wavefunctions

## Questions
- [x] For MP2 and CC*, we will need both relaxed and unrelaxed quantities. Is there a good reference on exactly what is meant by these terms, so that the schema can unambiguously define them? *Deferred*
- [x] Are there other pressing WF quantities that should be included in this PR? *Deferred*
- [x] We decided that AOs in `basis` are sorted according to "CCA" ordering as implicitly defined by Libint's default/CCA ordering. Is this information in our docs?
- [x] How should MOs be ordered? Increasing Fock matrix expectation value is the usual answer, but there is a case to be made for decreasing occupation number for correlated methods and excited states. We could also just not specify an ordering. *No ordering*
- [x] 2-index quantites are stored as lists. Are they row- or column-major? ~Does this appear somewhere else in QCSchema? Is it documented?~

## TODO
- [x] Return results as names instead of dupes
- [x] Resolve conversations

## Status
- [x] Autodocs 
- [x] Ready to go
